### PR TITLE
Add HTTPS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ $ ./pack.sh src
 - [Naoto Yokoyama](https://github.com/builtinnya) - the original author
 - [Gray-Wind](https://github.com/Gray-Wind) - support season popups
 - [Petrie Wong](https://github.com/petriewong) - update auto click golden cookies for v2.002
+- [mendel3](https://github.com/mendel3) - Add HTTPS support
 
 ## License
 

--- a/src/js/modules/config.js
+++ b/src/js/modules/config.js
@@ -5,6 +5,8 @@ var config = function () {
     cookieClickerUrls: [
       'http://orteil.dashnet.org/cookieclicker/',
       'http://orteil.dashnet.org/cookieclicker/beta/'
+      'https://orteil.dashnet.org/cookieclicker/',
+      'https://orteil.dashnet.org/cookieclicker/beta/'      
     ],
     defaultSettings: {
       autoClickCookie: false,

--- a/src/js/modules/config.js
+++ b/src/js/modules/config.js
@@ -4,7 +4,7 @@ var config = function () {
     extensionName: 'Uncanny Cookie Clicker',
     cookieClickerUrls: [
       'http://orteil.dashnet.org/cookieclicker/',
-      'http://orteil.dashnet.org/cookieclicker/beta/'
+      'http://orteil.dashnet.org/cookieclicker/beta/',
       'https://orteil.dashnet.org/cookieclicker/',
       'https://orteil.dashnet.org/cookieclicker/beta/'      
     ],

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -36,7 +36,9 @@
     {
       "matches": [
         "http://orteil.dashnet.org/cookieclicker/",
-        "http://orteil.dashnet.org/cookieclicker/beta/"
+        "http://orteil.dashnet.org/cookieclicker/beta/",
+        "https://orteil.dashnet.org/cookieclicker/",
+        "https://orteil.dashnet.org/cookieclicker/beta/"        
       ],
       "js": [
         "js/lib/underscore.js",


### PR DESCRIPTION
Cookie clicker has added an HTTPS version of the site, and this extension doesn't work on those sites.