### PR TITLE
Support Cookie Clicker v2.048 (multi-language)

### DIFF
--- a/src/js/page.js
+++ b/src/js/page.js
@@ -1,13 +1,13 @@
 ;(function (window, gameClient, pageMessaging, pageMessagingClient) {
 
-  var oldOnLoad = window.onload || function () {};
+  var origOnLoad = window.onload || function () {};
 
   window.onload = function () {
     if (!window.Game)
-      throw 'Error: Game is undefined.';
+      throw 'Error: Game is undefined: this extension may not support this version of Cookie Clicker.';
 
-    if (!window.Game.Init)
-      throw 'Error: Game.Init is undefined: This extension may not support this version of Cookie Clicker.';
+    if (!window.Game.Launch)
+      throw 'Error: Game.Launch is undefined: This extension may not support this version of Cookie Clicker.';
 
     var makeBuildingList = function (Game) {
       var buildingList = [];
@@ -19,33 +19,42 @@
       return buildingList;
     };
 
-    var oldGameInit = window.Game.Init;
+    const origGameLaunch = window.Game.Launch;
 
-    // Cookie Clicker calls Game.Init after loading assets asynchronously.
-    // So we replace Game.Init to make sure the client will be configured after
-    // initialization of Game.
-    window.Game.Init = function () {
-      // Call the initializer for Cookie Clicker.
-      oldGameInit();
+    window.Game.Launch = function () {
+      origGameLaunch();
 
-      // Now the Game object is initialized.
+      if (!window.Game.Init)
+      throw 'Error: Game.Init is undefined: This extension may not support this version of Cookie Clicker.';
 
-      // Initialize the game client.
-      gameClient.initialize();
+      const origGameInit = window.Game.Init;
 
-      // Initialize the messaging module.
-      pageMessaging.pageInitialize();
-      // Send information of game objects to the extension.
-      pageMessagingClient.sendToExtension({
-        cmd: 'UpdateBuildingList',
-        args: makeBuildingList(window.Game)
-      });
-      // Send a request for configuring game client to the extension.
-      pageMessagingClient.sendToExtension({ cmd: 'ConfigClient' });
+      // Cookie Clicker calls Game.Init after loading assets asynchronously.
+      // So we replace Game.Init to make sure the client will be configured after
+      // initialization of Game.
+      window.Game.Init = function () {
+        // Call the initializer for Cookie Clicker.
+        origGameInit();
+
+        // Now the Game object is initialized.
+
+        // Initialize the game client.
+        gameClient.initialize();
+
+        // Initialize the messaging module.
+        pageMessaging.pageInitialize();
+        // Send information of game objects to the extension.
+        pageMessagingClient.sendToExtension({
+          cmd: 'UpdateBuildingList',
+          args: makeBuildingList(window.Game)
+        });
+        // Send a request for configuring game client to the extension.
+        pageMessagingClient.sendToExtension({ cmd: 'ConfigClient' });
+      };
     };
 
     // Don't forget to trigger the initialization.
-    oldOnLoad();
+    origOnLoad();
   };
 
 })(window, gameClient, pageMessaging, pageMessagingClient);


### PR DESCRIPTION
fix #12 

Cookie Clicker v2.048 introduces multi-language feature, that shows initial language selection screen and breaks UncannyCookieClicker.

See: [Version History | Cookie Clicker Wiki | Fandom](https://cookieclicker.fandom.com/wiki/Version_History)

This PR fixes it and supports v2.048.