### PR TITLE
Update gameClient.js to fix the Cookie Storm problem.

### DIFF
--- a/src/js/modules/gameClient.js
+++ b/src/js/modules/gameClient.js
@@ -73,7 +73,9 @@ var gameClient = function (WatchJS, Game, pageMessagingClient) {
     if (goldenCookie.l.style.opacity == 0) {
       // wait for goldenCookie first update
       setTimeout(function(){
-        clickGoldenCookie(goldenCookie); 
+        if(Game.shimmers.includes(goldenCookie)){
+          clickGoldenCookie(goldenCookie); 
+        }
       }, 500);
     } else {
       goldenCookie.pop();


### PR DESCRIPTION
There is a classic async problem in the clickGoldenCookie function. The setTimeout just tries to repop the golden cookie in 500 ms, but it doesn't take into account that the cookie might have already been popped within that time (ex: by the autoclicker), which ends up meaning that you try to pop the cookie twice (which has a lot of bad side effects).

I fixed this by just making sure that the golden cookie hasn't been popped before popping it in the async setTimeout .